### PR TITLE
fix(date-picker): adding classes to allow date-picker calendar to adj…

### DIFF
--- a/core/scss/components/date-picker.scss
+++ b/core/scss/components/date-picker.scss
@@ -22,6 +22,18 @@
       top: 4px;
     }
 
+    &__dropdown {
+      .cui-event-overlay,
+      .cui-event-overlay__children {
+        position: absolute;
+      }
+
+      .cui-event-overlay--top {
+        top: auto;
+        bottom: 2.125rem;
+      }
+    }
+
     &__header {
       padding-top: $datepicker-header__padding-top;
     }


### PR DESCRIPTION
…ust for modal scrolling and partial cut off like dropdowns - CIR-328

## Description

Currently the angularjs calendar for date-picker does not adjust correctly for displaying on modals when scrolling.  Either the calendar would be in the wrong location (due to `position: fixed` and the modal screen being scrolled causing the calendar to `fix` itself below the visible screen) or it would be partially cut off due to the trigger button's on-screen location being close to the bottom of the screen.

The `.cui-datepicker__dropdown` class has been added to modify `.cui-event-overlay` classes specifically for date-pickers only to change `position: fixed` to `position: absolute` and allow for accurate positioning of the calendar above the trigger button in instances where having it below the button results in the calendar being unusable.

## Related Issue
Jira - https://jira-eng-sjc12.cisco.com/jira/browse/CIR-328 
Collab-ui-ng git issue - https://wwwin-github.cisco.com/collab-ui/collab-ui-ng/issues/209

## Motivation and Context
Date-pickers in Atlas became unusable in modals when modals were scrollable.

## How Has This Been Tested?
Tested in Atlas to be sure that date-pickers both inside and outside of modals worked as expected.  New class added to ensure no impact on existing react date-pickers.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
