### PR TITLE
feat(EditableTextfield): add prop allowEmpty to prevent empty value

### DIFF
--- a/react/src/lib/EditableTextfield/__snapshots__/index.spec.js.snap
+++ b/react/src/lib/EditableTextfield/__snapshots__/index.spec.js.snap
@@ -5,6 +5,7 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <EditableTextfield
     alignment="left"
+    allowEmpty={true}
     buttonClassName=""
     buttonProps={null}
     className=""

--- a/react/src/lib/EditableTextfield/index.js
+++ b/react/src/lib/EditableTextfield/index.js
@@ -24,31 +24,49 @@ class EditableTextfield extends React.Component {
   }
 
   handleEnter = (e, value) => {
-    const { handleDoneEditing } = this.props;
+    const { allowEmpty, handleDoneEditing } = this.props;
     e.persist();
 
-    this.setState(
-      {
-        isEditing: false,
-        inputText: value,
-      },
-      () => handleDoneEditing && handleDoneEditing(e, {value})
-    );
+    if(!allowEmpty && (!value || !value.replace(/\s/g, ''))) {
+      this.setState(
+        {
+          isEditing: false
+        },
+        () => handleDoneEditing && handleDoneEditing(e, {value})
+      ); 
+    } else {
+      this.setState(
+        {
+          isEditing: false,
+          inputText: value,
+        },
+        () => handleDoneEditing && handleDoneEditing(e, {value})
+      );
+    }
 
     e.nativeEvent.stopImmediatePropagation();
   }
 
   handleBlur = (e, value) => {
-    const { handleDoneEditing } = this.props;
+    const { allowEmpty, handleDoneEditing } = this.props;
     e.persist();
 
-    this.setState(
-      {
-        isEditing: false,
-        inputText: value,
-      },
-      () => handleDoneEditing && handleDoneEditing(e, {value})
-    );
+    if(!allowEmpty && (!value || !value.replace(/\s/g, ''))) {
+      this.setState(
+        {
+          isEditing: false
+        },
+        () => handleDoneEditing && handleDoneEditing(e, {value})
+      ); 
+    } else {
+      this.setState(
+        {
+          isEditing: false,
+          inputText: value,
+        },
+        () => handleDoneEditing && handleDoneEditing(e, {value})
+      );
+    }
   }
 
   handleEsc = e => {
@@ -103,6 +121,7 @@ class EditableTextfield extends React.Component {
     const { isEditing, inputText } = this.state;
 
     const inputProps = omit({...props}, [
+      'allowEmpty',
       'disabled',
       'handleDoneEditing',
       'inputText',
@@ -151,6 +170,8 @@ class EditableTextfield extends React.Component {
 EditableTextfield.propTypes = {
   /** @prop Alignment css modifier | 'left' */
   alignment: PropTypes.oneOf(['center', 'left', 'right']),
+  /** @prop Optional prop that prevents input from having null value | true */
+  allowEmpty: PropTypes.bool,
   /** @ Optional css class name for internal button | null */
   buttonClassName: PropTypes.string,
   /** @prop Optional props for internal button | '' */
@@ -167,6 +188,7 @@ EditableTextfield.propTypes = {
 
 EditableTextfield.defaultProps = {
   alignment: 'left',
+  allowEmpty: true,
   buttonClassName: '',
   buttonProps: null,
   className: '',

--- a/react/src/lib/EditableTextfield/index.spec.js
+++ b/react/src/lib/EditableTextfield/index.spec.js
@@ -102,7 +102,51 @@ describe('tests for <EditableTextfield />', () => {
     expect(container.find('Input').length).toEqual(0);
   });
 
-  it('should handle empty value', () => {
+  it('should handle allowEmpty prop with enter key', () => {
+    const container = mount(<EditableTextfield allowEmpty={false} inputText={'Hello World'}/>);
+    container.find('.cui-editable-textfield__button').simulate('click');
+
+    container.find('.cui-input').simulate('change', { target: { value: "" } });
+    container.find('.cui-input').simulate('keydown', { 
+      keyCode: 13,
+      key: 'Enter',
+      nativeEvent: { stopImmediatePropagation: ()=>{} }, 
+    });
+
+    expect(container.find('.cui-editable-textfield__button').text()).toEqual('Hello World');
+    expect(container.find('.cui-editable-textfield__button').length).toEqual(1);
+    expect(container.find('Input').length).toEqual(0);
+  });
+
+  it('should handle allowEmpty prop with string of empty spaces', () => {
+    const container = mount(<EditableTextfield allowEmpty={false} inputText={'Hello World'}/>);
+    container.find('.cui-editable-textfield__button').simulate('click');
+
+    container.find('.cui-input').simulate('change', { target: { value: "      " } });
+    container.find('.cui-input').simulate('keydown', { 
+      keyCode: 13,
+      key: 'Enter',
+      nativeEvent: { stopImmediatePropagation: ()=>{} }, 
+    });
+
+    expect(container.find('.cui-editable-textfield__button').text()).toEqual('Hello World');
+    expect(container.find('.cui-editable-textfield__button').length).toEqual(1);
+    expect(container.find('Input').length).toEqual(0);
+  });
+
+  it('should handle allowEmpty prop with blur', () => {
+    const container = mount(<EditableTextfield allowEmpty={false} inputText={'Hello World'}/>);
+    container.find('.cui-editable-textfield__button').simulate('click');
+
+    container.find('.cui-input').simulate('change', { target: { value: "" } });
+    container.find('.cui-input').simulate('blur');
+
+    expect(container.find('.cui-editable-textfield__button').text()).toEqual('Hello World');
+    expect(container.find('.cui-editable-textfield__button').length).toEqual(1);
+    expect(container.find('Input').length).toEqual(0);
+  });
+
+  it('should handle empty value with blur', () => {
     const container = mount(<EditableTextfield inputText={'Hello World'}/>);
     container.find('.cui-editable-textfield__button').simulate('click');
 
@@ -114,4 +158,19 @@ describe('tests for <EditableTextfield />', () => {
     expect(container.find('Input').length).toEqual(0);
   });
 
+  it('should handle empty value with enter', () => {
+    const container = mount(<EditableTextfield inputText={'Hello World'}/>);
+    container.find('.cui-editable-textfield__button').simulate('click');
+
+    container.find('.cui-input').simulate('change', { target: { value: "" } });
+    container.find('.cui-input').simulate('keydown', { 
+      keyCode: 13,
+      key: 'Enter',
+      nativeEvent: { stopImmediatePropagation: ()=>{} }, 
+    });
+
+    expect(container.find('.cui-editable-textfield__button').text()).toEqual('\u00a0');
+    expect(container.find('.cui-editable-textfield__button').length).toEqual(1);
+    expect(container.find('Input').length).toEqual(0);
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
@aimeex3 
Request to allow EditableTextfield to prevent an empty string as a value.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solves preventing users from entering empty strings.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added 4 new tests.
## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
