### PR TITLE
Input icon fix

### DIFF
--- a/core/scss/components/input.scss
+++ b/core/scss/components/input.scss
@@ -409,20 +409,13 @@
       padding-right: rem-calc(36);
     }
 
-    .#{$prefix}-button--icon,
-    .#{$prefix}-icon {
-      position: absolute;
-      top: rem-calc(11);
-      z-index: $input__focus-z-index + 1;
-    }
-
-    .#{$prefix}-input__icon,
-    .#{$prefix}-button--icon {
-      right: rem-calc(11);
-      left: auto;
-
-      @include input-clear-color;
-
+  .#{$prefix}-button--icon,
+  .#{$prefix}-icon {
+    position: absolute;
+    right: rem-calc(11);
+    left: auto;
+    z-index: $input__focus-z-index + 1;
+    
       .#{$prefix}-icon {
         position: relative;
         top: auto;
@@ -438,6 +431,10 @@
         );
       }
     }
+  }
+
+  .#{$prefix}-input__icon-clear {
+    @include input-clear-color;
   }
 
   .#{$input__class}--nested {

--- a/react/src/lib/Input/index.js
+++ b/react/src/lib/Input/index.js
@@ -183,20 +183,16 @@ class Input extends React.Component {
         name="clear-active_16"
         onClick={this.handleClear}
         ariaLabel={clearAriaLabel || 'clear input'}
+        className='cui-input__icon-clear'
       />
     );
-
-    const customInputIconNode = iconNode &&
-      React.cloneElement(iconNode, {
-        className: (iconNode.props.onClick ? '' : 'cui-input__icon')
-      });
 
     const iconContainer = () => {
       return (
         <div className='cui-input__icon-container'>
           {inputElement}
           {children}
-          {customInputIconNode || clearButton}
+          {iconNode || clearButton}
         </div>
       );
     };

--- a/react/src/lib/Input/index.spec.js
+++ b/react/src/lib/Input/index.spec.js
@@ -361,6 +361,6 @@ describe('tests for <Input />', () => {
       <Input id="test" label="test" value="test" iconNode={iconNode} />
     );
 
-    expect(container.find('.cui-input__icon').exists()).toEqual(true);
+    expect(container.find('.cui-icon').exists()).toEqual(true);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves #25, #23 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Removed cloning of class in Input as dom structure is unpredictable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->
![screen shot 2019-01-24 at 2 33 11 pm](https://user-images.githubusercontent.com/36969382/51706831-3a718200-1fe5-11e9-9055-c01f5f445bde.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
