### PR TITLE
fix(modal): Modals go full screen on vertically small screens.

### DIFF
--- a/core/scss/components/modal.scss
+++ b/core/scss/components/modal.scss
@@ -264,12 +264,6 @@
           $min-height: $modal__height--small
         );
       }
-
-      @media #{$v-small-only} {
-        .#{$modal__class}__content {
-          min-height: auto
-        }
-      }
     }
 
     &.#{$modal__class}--dialog {
@@ -329,7 +323,8 @@
     &.#{$modal__class}--default,
     &.#{$modal__class}--dialog {
       //Media Query for Mobile
-      @media #{$small-only} {
+      @media #{$small-only},
+      #{$v-small-only} {
         @include modal-size($radius: 0, $height: 100vh);
 
         .#{$modal__class}__flex-container {
@@ -374,7 +369,8 @@
       }
 
       &.#{$modal__class}--dialog {
-        @media #{$small-only} {
+        @media #{$small-only},
+        #{$v-small-only} {
           .#{$modal__class}__flex-container {
             min-height: calc(100vh - (#{$modal-dialog__padding} * 2));
           }


### PR DESCRIPTION
## Description
- On horizontally small screens, modals were already going to full screen.
- Updating the existing behavior to also apply to vertically small screens.
- Related to PROVISION-4260

## How Has This Been Tested?
Tested in Atlas/Control Hub

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
