### PR TITLE
Add missing tests for the Name prop in the react Icon component

### DIFF
--- a/react/src/lib/Icon/index.spec.js
+++ b/react/src/lib/Icon/index.spec.js
@@ -13,30 +13,6 @@ describe('Tests for <Icon />', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should wrap in button', () => {
-    const props = {
-      name: 'accessibility_16',
-      onClick: ()=>{},
-      ariaLabel: 'Accesible',
-    };
-
-    const container = mount(<Icon {...props} />);
-    expect(container.find('.cui-button').exists()).toEqual(true);
-    expect(container.find('.cui-button--icon').exists()).toEqual(true);
-  });
-
-  it('should wrap in button and add type class', () => {
-    const props = {
-      name: 'accessibility_16',
-      type: 'white',
-      onClick: ()=>{},
-      ariaLabel: 'Accesible',
-    };
-
-    const container = mount(<Icon {...props} />);
-    expect(container.find('.cui-button--icon-white').exists()).toEqual(true);
-  });
-
   describe('Test the sizes of <Icon />', () => {
     it('should match SnapShot', () => {
       const props = {
@@ -82,6 +58,26 @@ describe('Tests for <Icon />', () => {
     });
   });
 
+  describe('Test the name prop of <Icon />', () => {
+    it('should be able to take the name without the "icon-" prefix', () => {
+      const props = {
+        name: 'accessibility_16',
+      };
+      const container = mount(<Icon {...props} />);
+      const iEle = container.find('i');
+      expect(iEle.props().className).toEqual('cui-icon icon icon-accessibility_16');
+    });
+
+    it('should be able to take the name WITH the "icon-" prefix', () => {
+      const props = {
+        name: 'icon-accessibility_16',
+      };
+      const container = mount(<Icon {...props} />);
+      const iEle = container.find('i');
+      expect(iEle.props().className).toEqual('cui-icon icon icon-accessibility_16');
+    });
+  });
+
   it('should pass the classNames onto the icon', () => {
     const props = {
       name: 'accessibility_16',
@@ -103,17 +99,43 @@ describe('Tests for <Icon />', () => {
     expect(iEle.props().id).toEqual(props.id);
   });
 
-  it('should pass other props to the button if onClick Present', () => {
-    const props = {
-      name: 'accessibility_16',
-      className: 'testClass',
-      id: 'testId',
-      ariaLabel: 'Testing',
-      onClick: ()=>{}
-    };
-    const container = mount(<Icon {...props} />);
-    const buttonEle = container.find('button');
-    expect(buttonEle.props().id).toEqual(props.id);
+  describe('Test the button <Icon />', () => {
+    it('should wrap in button', () => {
+      const props = {
+        name: 'accessibility_16',
+        onClick: () => {},
+        ariaLabel: 'Accesible',
+      };
+
+      const container = mount(<Icon {...props} />);
+      expect(container.find('.cui-button').exists()).toEqual(true);
+      expect(container.find('.cui-button--icon').exists()).toEqual(true);
+    });
+
+    it('should wrap in button and add type class', () => {
+      const props = {
+        name: 'accessibility_16',
+        type: 'white',
+        onClick: () => {},
+        ariaLabel: 'Accesible',
+      };
+
+      const container = mount(<Icon {...props} />);
+      expect(container.find('.cui-button--icon-white').exists()).toEqual(true);
+    });
+
+    it('should pass other props to the button if onClick Present', () => {
+      const props = {
+        name: 'accessibility_16',
+        className: 'testClass',
+        id: 'testId',
+        ariaLabel: 'Testing',
+        onClick: () => {},
+      };
+      const container = mount(<Icon {...props} />);
+      const buttonEle = container.find('button');
+      expect(buttonEle.props().id).toEqual(props.id);
+    });
   });
 
   describe('Test the colors of <Icon />', () => {


### PR DESCRIPTION
## Related Issue
#87 fix(Icon): allow icon name to be prefixed with icon

## Motivation and Context
Missing tests for the name prop. Functionality was broken when the component was refactored in #82

## How Has This Been Tested?
2 new tests added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Testing

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
