### PR TITLE
fix(SpaceListMeeting): add isIMOnlyShare prop and blue button

### DIFF
--- a/react/src/lib/SpaceListMeeting/__snapshots__/index.spec.js.snap
+++ b/react/src/lib/SpaceListMeeting/__snapshots__/index.spec.js.snap
@@ -13,6 +13,7 @@ ShallowWrapper {
     header="header"
     id=""
     isBold={false}
+    isMessagingOnlyShare={false}
     meetingType=""
     subheader=""
     title=""

--- a/react/src/lib/SpaceListMeeting/index.js
+++ b/react/src/lib/SpaceListMeeting/index.js
@@ -36,6 +36,7 @@ class SpaceListMeeting extends React.PureComponent {
       childrenRight,
       className,
       header,
+      isMessagingOnlyShare,
       isBold,
       meetingType,
       subheader,
@@ -119,8 +120,8 @@ class SpaceListMeeting extends React.PureComponent {
                 tabIndex={0}
                 className='cui-list-item--space-meeting--attendees'
               >
-                {attendees.length}
-                <Icon name='people_12' />
+                {isMessagingOnlyShare ? null : attendees.length}
+                {isMessagingOnlyShare ? <Icon name='share-screen_12' /> : <Icon name='people_12' />}
               </span>
             </Popover>
           }
@@ -128,7 +129,7 @@ class SpaceListMeeting extends React.PureComponent {
             buttonLabel
             &&
             <Button
-              color='green'
+              color={isMessagingOnlyShare ? 'blue' : 'green'}
               ariaLabel={buttonLabel}
               children={buttonLabel}
               onClick={this.handleButtonClick}
@@ -183,6 +184,8 @@ SpaceListMeeting.propTypes = {
   id: PropTypes.string,
   /** @prop Determines if SpaceListMeeting is Bolded | false */
   isBold: PropTypes.bool,
+  /** @prop Determines if SpaceListMeeting is IM share only | false */
+  isMessagingOnlyShare: PropTypes.bool,
   /** @prop Set the SpaceListMeeting type | '' */
   meetingType: PropTypes.oneOf(['', 'group', 'number', 'device']),
   /** @prop SpaceListMeeting sub header node | '' */
@@ -200,6 +203,7 @@ SpaceListMeeting.defaultProps = {
   className: '',
   id: '',
   isBold: false,
+  isMessagingOnlyShare: false,
   meetingType: '',
   subheader: '',
   title: ''

--- a/react/src/lib/SpaceListMeeting/index.spec.js
+++ b/react/src/lib/SpaceListMeeting/index.spec.js
@@ -32,10 +32,10 @@ describe('tests for <SpaceListMeeting />', () => {
   });
 
   it('should render attendees prop', () => {
-    
+
     const container = mount(
-      <SpaceListMeeting 
-        header='header'   
+      <SpaceListMeeting
+        header='header'
         attendees={[
           {title: 'Joe Bojangles'},
           {title: 'Joe Boe'},
@@ -55,8 +55,8 @@ describe('tests for <SpaceListMeeting />', () => {
 
   it('should render attendees prop(node property)', () => {
     const container = mount(
-      <SpaceListMeeting 
-        header='header'   
+      <SpaceListMeeting
+        header='header'
         attendees={[
           {title: 'Joe Bojangles', node: <div className='internalNode' />},
         ]}
@@ -94,12 +94,12 @@ describe('tests for <SpaceListMeeting />', () => {
         header='header'
       />
     );
-    
+
     container.find('.cui-button').simulate('click');
     expect(onClick).toHaveBeenCalled();
     expect(onClickParent).not.toHaveBeenCalled();
   });
-  
+
   it('should handle buttonOnClick and execute keyPress', () => {
     const onClick = jest.fn();
     const onClickParent = jest.fn();
@@ -111,7 +111,7 @@ describe('tests for <SpaceListMeeting />', () => {
         header='header'
       />
     );
-    
+
     container
       .find('.cui-button')
       .simulate('keyDown', { which: 13, charCode: 13, key: 'Space' });
@@ -173,26 +173,33 @@ describe('tests for <SpaceListMeeting />', () => {
   describe('tests for title Prop', () => {
     it('should not have title by default if header is node', () => {
       const container = mount(
-        <SpaceListMeeting header={<div>test</div>} />        
+        <SpaceListMeeting header={<div>test</div>} />
       );
-  
+
       expect(container.find('.cui-list-item').props().title).toEqual(undefined);
     });
 
     it('should handle title prop', () => {
       const container = mount(
-        <SpaceListMeeting header='header' title='testTitle'/>        
+        <SpaceListMeeting header='header' title='testTitle'/>
       );
-  
+
       expect(container.find('.cui-list-item').props().title).toEqual('testTitle');
     });
 
     it('should handle title if header is string', () => {
       const container = mount(
-        <SpaceListMeeting header='testTitle'/>        
+        <SpaceListMeeting header='testTitle'/>
       );
-  
+
       expect(container.find('.cui-list-item').props().title).toEqual('testTitle');
+    });
+
+    it('should handle isMessagingOnlyShare prop', () => {
+      const container = mount(
+        <SpaceListMeeting buttonLabel='Label' header='header' isMessagingOnlyShare/>
+      );
+      expect(container.find('.cui-button').hasClass('cui-button--blue')).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add props ```isIMOnlyShare``` for SpaceListMeeting.
If ```isIMOnlyShare``` is set to ```true```,
1. Change the button color to ```blue```
2. Change the icon to ```share```
3. Remove the number of participants

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/collab-ui/collab-ui/issues/117

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Support IM only share feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Add unit test for new props.

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
