### PR TITLE
feat(AlertCall): add onAnswerShare option

### DIFF
--- a/react/src/lib/AlertCall/__snapshots__/index.spec.js.snap
+++ b/react/src/lib/AlertCall/__snapshots__/index.spec.js.snap
@@ -14,15 +14,17 @@ ShallowWrapper {
     defaultSelectedDevice={0}
     deviceListHeader="Device selection"
     devices={Array []}
+    onAnswerShare={null}
     onAnswerVideo={null}
     onAnswerVoice={null}
     onDeviceSelect={null}
     onReject={null}
     rejectAriaLabel="reject call"
+    shareAriaLabel="answer call with share"
     show={true}
     title="Incoming call"
-    videoAriaLabel="answer call with voice and video"
-    voiceAriaLabel="answer call with voice only"
+    videoAriaLabel="answer call with video"
+    voiceAriaLabel="answer call with voice"
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -81,43 +83,6 @@ ShallowWrapper {
         <div
           className="cui-alert--call--buttons"
         >
-          <Button
-            active={false}
-            ariaLabel="answer call with voice and video"
-            ariaLabelledBy=""
-            circle={true}
-            className=""
-            color="green"
-            containerLarge={false}
-            disabled={false}
-            expand={false}
-            href=""
-            index={null}
-            isButtonGroup={false}
-            label=""
-            large={false}
-            loading={false}
-            onClick={null}
-            removeStyle={false}
-            size={44}
-            style={Object {}}
-            tag="button"
-            type="button"
-          >
-            <Icon
-              ariaLabel={null}
-              buttonClassName=""
-              className=""
-              color=""
-              description=""
-              isAria={true}
-              name="camera_24"
-              onClick={null}
-              size={null}
-              title=""
-              type=""
-            />
-          </Button>
           <Button
             active={false}
             ariaLabel="reject call"
@@ -284,43 +249,8 @@ ShallowWrapper {
         "nodeType": "host",
         "props": Object {
           "children": Array [
-            <Button
-              active={false}
-              ariaLabel="answer call with voice and video"
-              ariaLabelledBy=""
-              circle={true}
-              className=""
-              color="green"
-              containerLarge={false}
-              disabled={false}
-              expand={false}
-              href=""
-              index={null}
-              isButtonGroup={false}
-              label=""
-              large={false}
-              loading={false}
-              onClick={null}
-              removeStyle={false}
-              size={44}
-              style={Object {}}
-              tag="button"
-              type="button"
-            >
-              <Icon
-                ariaLabel={null}
-                buttonClassName=""
-                className=""
-                color=""
-                description=""
-                isAria={true}
-                name="camera_24"
-                onClick={null}
-                size={null}
-                title=""
-                type=""
-              />
-            </Button>,
+            null,
+            null,
             null,
             <Button
               active={false}
@@ -364,70 +294,8 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": Array [
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "active": false,
-              "ariaLabel": "answer call with voice and video",
-              "ariaLabelledBy": "",
-              "children": <Icon
-                ariaLabel={null}
-                buttonClassName=""
-                className=""
-                color=""
-                description=""
-                isAria={true}
-                name="camera_24"
-                onClick={null}
-                size={null}
-                title=""
-                type=""
-              />,
-              "circle": true,
-              "className": "",
-              "color": "green",
-              "containerLarge": false,
-              "disabled": false,
-              "expand": false,
-              "href": "",
-              "index": null,
-              "isButtonGroup": false,
-              "label": "",
-              "large": false,
-              "loading": false,
-              "onClick": null,
-              "removeStyle": false,
-              "size": 44,
-              "style": Object {},
-              "tag": "button",
-              "type": "button",
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "ariaLabel": null,
-                "buttonClassName": "",
-                "className": "",
-                "color": "",
-                "description": "",
-                "isAria": true,
-                "name": "camera_24",
-                "onClick": null,
-                "size": null,
-                "title": "",
-                "type": "",
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            "type": [Function],
-          },
+          null,
+          null,
           null,
           Object {
             "instance": null,
@@ -548,43 +416,6 @@ ShallowWrapper {
           <div
             className="cui-alert--call--buttons"
           >
-            <Button
-              active={false}
-              ariaLabel="answer call with voice and video"
-              ariaLabelledBy=""
-              circle={true}
-              className=""
-              color="green"
-              containerLarge={false}
-              disabled={false}
-              expand={false}
-              href=""
-              index={null}
-              isButtonGroup={false}
-              label=""
-              large={false}
-              loading={false}
-              onClick={null}
-              removeStyle={false}
-              size={44}
-              style={Object {}}
-              tag="button"
-              type="button"
-            >
-              <Icon
-                ariaLabel={null}
-                buttonClassName=""
-                className=""
-                color=""
-                description=""
-                isAria={true}
-                name="camera_24"
-                onClick={null}
-                size={null}
-                title=""
-                type=""
-              />
-            </Button>
             <Button
               active={false}
               ariaLabel="reject call"
@@ -751,43 +582,8 @@ ShallowWrapper {
           "nodeType": "host",
           "props": Object {
             "children": Array [
-              <Button
-                active={false}
-                ariaLabel="answer call with voice and video"
-                ariaLabelledBy=""
-                circle={true}
-                className=""
-                color="green"
-                containerLarge={false}
-                disabled={false}
-                expand={false}
-                href=""
-                index={null}
-                isButtonGroup={false}
-                label=""
-                large={false}
-                loading={false}
-                onClick={null}
-                removeStyle={false}
-                size={44}
-                style={Object {}}
-                tag="button"
-                type="button"
-              >
-                <Icon
-                  ariaLabel={null}
-                  buttonClassName=""
-                  className=""
-                  color=""
-                  description=""
-                  isAria={true}
-                  name="camera_24"
-                  onClick={null}
-                  size={null}
-                  title=""
-                  type=""
-                />
-              </Button>,
+              null,
+              null,
               null,
               <Button
                 active={false}
@@ -831,70 +627,8 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": Array [
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "active": false,
-                "ariaLabel": "answer call with voice and video",
-                "ariaLabelledBy": "",
-                "children": <Icon
-                  ariaLabel={null}
-                  buttonClassName=""
-                  className=""
-                  color=""
-                  description=""
-                  isAria={true}
-                  name="camera_24"
-                  onClick={null}
-                  size={null}
-                  title=""
-                  type=""
-                />,
-                "circle": true,
-                "className": "",
-                "color": "green",
-                "containerLarge": false,
-                "disabled": false,
-                "expand": false,
-                "href": "",
-                "index": null,
-                "isButtonGroup": false,
-                "label": "",
-                "large": false,
-                "loading": false,
-                "onClick": null,
-                "removeStyle": false,
-                "size": 44,
-                "style": Object {},
-                "tag": "button",
-                "type": "button",
-              },
-              "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "ariaLabel": null,
-                  "buttonClassName": "",
-                  "className": "",
-                  "color": "",
-                  "description": "",
-                  "isAria": true,
-                  "name": "camera_24",
-                  "onClick": null,
-                  "size": null,
-                  "title": "",
-                  "type": "",
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              "type": [Function],
-            },
+            null,
+            null,
             null,
             Object {
               "instance": null,

--- a/react/src/lib/AlertCall/index.js
+++ b/react/src/lib/AlertCall/index.js
@@ -17,11 +17,13 @@ const AlertCall = props => {
     defaultSelectedDevice,
     deviceListHeader,
     devices,
+    onAnswerShare,
     onAnswerVideo,
     onAnswerVoice,
     onDeviceSelect,
     onReject,
     rejectAriaLabel,
+    shareAriaLabel,
     show,
     title,
     videoAriaLabel,
@@ -70,14 +72,26 @@ const AlertCall = props => {
           {getDeviceList()}
         </UIDReset>
         <div className='cui-alert--call--buttons'>
-          <Button
-            children={<Icon name='camera_24'/>}
-            onClick={onAnswerVideo}
-            ariaLabel={videoAriaLabel}
-            color='green'
-            circle
-            size={44}
-          />
+          {onAnswerShare &&
+            <Button
+              children={<Icon name='share-screen_24'/>}
+              onClick={onAnswerShare}
+              ariaLabel={shareAriaLabel}
+              color='blue'
+              circle
+              size={44}
+            />
+          }
+          {onAnswerVideo &&
+            <Button
+              children={<Icon name='camera_24'/>}
+              onClick={onAnswerVideo}
+              ariaLabel={videoAriaLabel}
+              color='green'
+              circle
+              size={44}
+            />
+          }
           {onAnswerVoice &&
             <Button
               children={<Icon name='handset_24'/>}
@@ -108,14 +122,16 @@ AlertCall.defaultProps = {
   defaultSelectedDevice: 0,
   deviceListHeader: 'Device selection',
   devices: [],
+  onAnswerShare: null,
   onAnswerVideo: null,
   onAnswerVoice: null,
   onDeviceSelect: null,
   onReject: null,
   rejectAriaLabel: 'reject call',
+  shareAriaLabel: 'answer call with share',
   title: '',
-  videoAriaLabel: 'answer call with voice and video',
-  voiceAriaLabel: 'answer call with voice only',
+  videoAriaLabel: 'answer call with video',
+  voiceAriaLabel: 'answer call with voice',
 };
 
 AlertCall.propTypes = {
@@ -134,6 +150,8 @@ AlertCall.propTypes = {
   deviceListHeader: PropTypes.string,
   /** @prop Optional list of devices to answer call with | [] */
   devices: PropTypes.array,
+  /** @prop Callback function invoked when the share button is clicked | null */
+  onAnswerShare: PropTypes.func,
   /** @prop Callback function invoked when the video button is clicked | null */
   onAnswerVideo: PropTypes.func,
   /** @prop Callback function invoked when the handset button is clicked | null */
@@ -144,11 +162,13 @@ AlertCall.propTypes = {
   onReject: PropTypes.func,
   /** @prop Optional aria-label reject message | 'reject call' */
   rejectAriaLabel: PropTypes.string,
+  /** @prop Optional aria-label share | 'answer call with share' */
+  shareAriaLabel: PropTypes.string,
   /** @prop Required AlertCall visitibility setting */
   show: PropTypes.bool.isRequired,
   /** @prop Optional title of AlertCall | '' */
   title: PropTypes.string,
-  /** @prop Optional aria-label video | 'answer call with voice and video' */
+  /** @prop Optional aria-label video | 'answer call with video' */
   videoAriaLabel: PropTypes.string,
   /** @prop Optional aria-label voice | 'answer call with voice only' */
   voiceAriaLabel: PropTypes.string,

--- a/react/src/lib/AlertCall/index.spec.js
+++ b/react/src/lib/AlertCall/index.spec.js
@@ -21,107 +21,225 @@ describe('tests for <AlertCall />', () => {
   };
 
   it('should match SnapShot', () => {
-    const container = shallow(<AlertCall show caller={caller1} title={alertTitle}/>);
+    const container = shallow(
+      <AlertCall 
+        show
+        caller={caller1}
+        title={alertTitle}
+      />
+    );
 
     expect(container).toMatchSnapshot();
   });
 
   it('should render one AlertCall', () => {
-    const container = mount(<AlertCall show caller={caller1} title={alertTitle} />);
+    const container = mount(
+      <AlertCall 
+        show
+        caller={caller1}
+        title={alertTitle}
+      />);
 
     expect(container.find('.cui-alert.cui-alert--call').length).toEqual(1);
   });
 
   it('should handle rejectAriaLabel', () => {
-    const container = mount(<AlertCall show caller={caller2} title={alertTitle} rejectAriaLabel='rejectLabel' />);
+    const container = mount(
+      <AlertCall 
+        show
+        caller={caller2}
+        title={alertTitle}
+        rejectAriaLabel='rejectLabel'
+      />);
 
     expect(container.find('button').last().props()['aria-label']).toEqual('rejectLabel');
   });
 
+  it('should handle shareAriaLabel', () => {
+    const container = mount(
+      <AlertCall 
+        show
+        caller={caller2}
+        title={alertTitle}
+        shareAriaLabel='shareAriaLabel'
+        onAnswerShare={() => {}}  
+      />);
+
+    expect(container.find('button').first().props()['aria-label']).toEqual('shareAriaLabel');
+  });
+
   it('should handle videoAriaLabel', () => {
-    const container = mount(<AlertCall show caller={caller2} title={alertTitle} videoAriaLabel='videoAriaLabel' />);
+    const container = mount(
+      <AlertCall 
+        show
+        caller={caller2}
+        title={alertTitle}
+        videoAriaLabel='videoAriaLabel'
+        onAnswerVideo={() => {}}  
+      />);
 
     expect(container.find('button').first().props()['aria-label']).toEqual('videoAriaLabel');
   });
 
   it('should handle voiceAriaLabel', () => {
-    const container = mount(<AlertCall show caller={caller2} title={alertTitle} voiceAriaLabel='voiceLabel' onAnswerVoice={() => {}} />);
+    const container = mount(
+      <AlertCall 
+        show
+        caller={caller2}
+        title={alertTitle}
+        voiceAriaLabel='voiceLabel'
+        onAnswerVoice={() => {}} 
+      />);
 
-    expect(container.find('button').at(1).props()['aria-label']).toEqual('voiceLabel');
+    expect(container.find('button').first().props()['aria-label']).toEqual('voiceLabel');
   });
 
   it('should render meeting title', () => {
-    const container = shallow(<AlertCall show caller={caller2} title={alertTitle} />);
+    const container = shallow(
+      <AlertCall 
+        show
+        caller={caller2}
+        title={alertTitle} 
+      />);
 
     expect(container.find('.cui-alert__title').text()).toEqual('Incoming call');
   });
 
   it('should render an avatar', () => {
-    const container = mount(<AlertCall show caller={caller2} title={alertTitle} />);
+    const container = mount(
+      <AlertCall 
+        show
+        caller={caller2}
+        title={alertTitle} 
+      />);
 
     expect(container.find(Avatar).length).toEqual(1);
   });
 
   it('should handle caller.title prop', () => {
-    const container = shallow(<AlertCall show caller={caller1} title={alertTitle} />);
+    const container = shallow(
+      <AlertCall 
+        show
+        caller={caller1}
+        title={alertTitle} 
+      />);
 
     expect(container.find('.cui-alert__caller-title').text()).toEqual('Jefe Guadelupe');
   });
 
   it('should handle caller.alt prop', () => {
-    const container = shallow(<AlertCall show caller={caller1} title={alertTitle} />);
+    const container = shallow(
+      <AlertCall 
+        show
+        caller={caller1}
+        title={alertTitle} 
+      />);
 
     expect(container.find('.cui-alert__caller-subtitle').text()).toEqual('+1 408-555-1212');
   });
 
   describe('should handle caller.type', () => {
     it('should handle number', () => {
-      const container = mount(<AlertCall show caller={caller2} title={alertTitle}/>);
+      const container = mount(
+        <AlertCall 
+          show
+          caller={caller2}
+          title={alertTitle}
+        />);
 
       expect(container.find('.cui-avatar__letter').text()).toEqual('#');
     });
 
     it('should handle device', () => {
-      const container = mount(<AlertCall show caller={caller3} title={alertTitle}/>);
+      const container = mount(
+        <AlertCall 
+          show
+          caller={caller3}
+          title={alertTitle}
+        />);
 
       expect(container.find('.cui-avatar__icon').length).toEqual(1);
     });
   });
 
-  it('should render three action buttons when onAnswerVoice is passed in', () => {
-    const container = mount(<AlertCall show caller={caller1} title={alertTitle} onAnswerVoice={() => {}} />);
-
-    expect(container.find('.cui-button').length).toEqual(3);
-  });
-
-  it('should render two action buttons when onAnswerVoice is not passed in', () => {
-    const container = mount(<AlertCall show caller={caller1} title={alertTitle} />);
+  it('should render two action buttons when onAnswerVoice is passed in', () => {
+    const container = mount(
+      <AlertCall 
+        show
+        caller={caller1}
+        title={alertTitle}
+        onAnswerVoice={() => {}} 
+      />);
 
     expect(container.find('.cui-button').length).toEqual(2);
+  });
+
+  it('should render reject action button when nothing else is passed in', () => {
+    const container = mount(
+      <AlertCall 
+        show
+        caller={caller1}
+        title={alertTitle} 
+      />);
+
+    expect(container.find('.cui-button').length).toEqual(1);
   });
 
   it('should handle onReject event', () => {
     let count = 0;
     const countUp = () => count++;
-    const container = mount(<AlertCall show caller={caller1} title={alertTitle} onReject={countUp} />);
+    const container = mount(
+      <AlertCall 
+        show
+        caller={caller1}
+        title={alertTitle}
+        onReject={countUp} 
+      />);
 
     container.find('.cui-button').last().simulate('click');
+    expect(count).toEqual(1);
+  });
+
+  it('should handle onAnswerShare event', () => {
+    let count = 0;
+    const countUp = () => count++;
+    const container = mount(
+      <AlertCall 
+        show
+        caller={caller1}
+        title={alertTitle}
+        onAnswerShare={countUp} 
+      />);
+
+    container.find('.cui-button').first().simulate('click');
     expect(count).toEqual(1);
   });
 
   it('should handle onAnswerVoice event', () => {
     let count = 0;
     const countUp = () => count++;
-    const container = mount(<AlertCall show caller={caller1} title={alertTitle} onAnswerVoice={countUp} />);
+    const container = mount(
+      <AlertCall 
+        show
+        caller={caller1}
+        title={alertTitle}
+        onAnswerVoice={countUp} 
+      />);
 
-    container.find('.cui-button').at(1).simulate('click');
+    container.find('.cui-button').first().simulate('click');
     expect(count).toEqual(1);
   });
 
   it('should handle onAnswerVideo event', () => {
     let count = 0;
     const countUp = () => count++;
-    const container = mount(<AlertCall show caller={caller1} title={alertTitle} onAnswerVideo={countUp} />);
+    const container = mount(
+      <AlertCall 
+        show
+        caller={caller1}
+        title={alertTitle}
+        onAnswerVideo={countUp} 
+      />);
 
     container.find('.cui-button').first().simulate('click');
     expect(count).toEqual(1);


### PR DESCRIPTION
BREAKING CHANGE

- onAnswerVideo function prop must be included to include video button

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #118 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
