### PR TITLE
feat(AlertMeeting): add Angular Meeting Alert component

### DIFF
--- a/angular/src/lib/alert-meeting/alert-meeting-config.ts
+++ b/angular/src/lib/alert-meeting/alert-meeting-config.ts
@@ -1,0 +1,42 @@
+import { TemplateRef } from '@angular/core';
+
+export interface AlertMeetingAttendee {
+  title: string;
+  alt?: string;
+  src?: string;
+}
+
+// Configuration used when opening an alert.
+export class AlertMeetingConfig {
+  key?: string;
+
+  /** Optional attendee array. If more than one attendee, a Composite Avatar with only the first 2 attendees is created. */
+  attendees?: AlertMeetingAttendee[] = [];
+
+  /** Optional avatar prop | null */
+  avatar?: TemplateRef<any>;
+
+  /** Optional aria label for the close button | 'close' */
+  closeAriaLabel?: string = 'close';
+
+  /** Optional AlertMeeting Message | '' */
+  message: string = '';
+
+  /** Optional aria label for snooze buton | 'snooze' */
+  remindAriaLabel?: string = 'snooze';
+
+  /** Optional AlertMeeting status | '' */
+  status: string = '';
+
+  /** Optional AlertMeeting title | '' */
+  title: string = '';
+
+  /** Optional callback function invoked on click of alert | null */
+  onClick?: Function = null;
+
+  /** Optional handler invoked when the user presses on the Alert's close button or hit's the esc key | null */
+  onHide?: Function = null;
+
+  /** Optional callback function invoked when the snooze button is clicked | null */
+  onSnooze?: Function = null;
+}

--- a/angular/src/lib/alert-meeting/alert-meeting-container.component.ts
+++ b/angular/src/lib/alert-meeting/alert-meeting-container.component.ts
@@ -1,0 +1,84 @@
+import { Component, OnDestroy } from '@angular/core';
+import { AlertMeetingConfig } from './alert-meeting-config';
+import find from 'lodash-es/find';
+import reject from 'lodash-es/reject';
+import uniqueId from 'lodash-es/uniqueId';
+import { Subject } from 'rxjs';
+
+// Used internally by the alert meeting service.
+@Component({
+  selector: 'cui-alert-meeting-container',
+  template: `
+    <cui-alert-meeting *ngFor="let alert of alertList"
+      [key]="alert.key"
+      [attendees]="alert.attendees"
+      [avatar]="alert.avatar"
+      [clickable]="!!alert.onClick"
+      [closeAriaLabel]="alert.closeAriaLabel"
+      [message]="alert.message"
+      [remindAriaLabel]="alert.remindAriaLabel"
+      [snoozeButtonVisible]="!!alert.onSnooze"
+      [status]="alert.status"
+      [title]="alert.title"
+      (mouseclick)="onClick($event)"
+      (hide)="onHide($event)"
+      (snooze)="onSnooze($event)"
+    ></cui-alert-meeting>
+  `,
+  host: {
+    'class': 'cui-alert__container cui-alert__container--bottom-right'
+  }
+})
+
+export class AlertMeetingContainerComponent implements OnDestroy {
+
+  readonly _onDestroy: Subject<any> = new Subject();
+
+  alertList: Array<AlertMeetingConfig> = [];
+
+  addAlert(alert: AlertMeetingConfig): string {
+    alert.key = uniqueId('alert_meeting_');
+    this.alertList.push(alert);
+    return alert.key;
+  }
+
+  removeAlert(key: string): void {
+    this.alertList = reject(this.alertList, { key });
+    if (!this.alertList.length) {
+      this.destroy();
+    }
+  }
+
+  onClick(key: string): void {
+    const alert = find(this.alertList, { key });
+    if (alert && alert.onClick) {
+      alert.onClick();
+    }
+    this.removeAlert(key);
+  }
+
+  onHide(key: string): void {
+    const alert = find(this.alertList, { key });
+    if (alert && alert.onHide) {
+      alert.onHide();
+    }
+    this.removeAlert(key);
+  }
+
+  onSnooze(key: string): void {
+    const alert = find(this.alertList, { key });
+    if (alert && alert.onSnooze) {
+      alert.onSnooze();
+    }
+    this.removeAlert(key);
+  }
+
+  destroy(): void {
+    this._onDestroy.next();
+    this._onDestroy.complete();
+  }
+
+  ngOnDestroy() {
+    this.destroy();
+  }
+}

--- a/angular/src/lib/alert-meeting/alert-meeting.component.ts
+++ b/angular/src/lib/alert-meeting/alert-meeting.component.ts
@@ -1,0 +1,123 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  TemplateRef,
+} from '@angular/core';
+
+import { AlertMeetingAttendee } from './alert-meeting-config';
+
+// Used internally by the alert meeting service.
+@Component({
+  selector: 'cui-alert-meeting',
+  template: `
+    <ng-container *ngIf="avatar; else avatarTemplate" [ngTemplateOutlet]="avatar"></ng-container>
+    <div [ngClass]="contentClasses">
+      <div class="cui-alert__title" [attr.title]="title">{{ title }}</div>
+      <div class="cui-alert__status">{{ status }}</div>
+      <div class="cui-alert__message" [attr.title]="message">{{ message }}</div>
+    </div>
+    <div class="cui-alert__button" *ngIf="snoozeButtonVisible">
+      <button
+        cui-button
+        [attr.aria-label]="remindAriaLabel"
+        [circle]="true"
+        size="44"
+        tabindex="0"
+        (click)="onSnooze()"
+      >
+        <cui-icon name="alarm_16"></cui-icon>
+      </button>
+    </div>
+    <div class="cui-alert__button">
+      <button
+        cui-button
+        [attr.aria-label]="closeAriaLabel"
+        [circle]="true"
+        size="44"
+        tabindex="0"
+        (click)="onHide()"
+      >
+        <cui-icon name="cancel_16"></cui-icon>
+      </button>
+    </div>
+
+    <ng-template #avatarTemplate>
+      <cui-composite-avatar *ngIf="attendees.length >= 2">
+        <cui-avatar
+          [title]="attendees[0].title"
+          [alt]="attendees[0].alt"
+          [src]="attendees[0].src"
+        ></cui-avatar>
+        <cui-avatar
+          [title]="attendees[1].title"
+          [alt]="attendees[1].alt"
+          [src]="attendees[1].src"
+        ></cui-avatar>
+      </cui-composite-avatar>
+      <cui-avatar
+        *ngIf="attendees.length === 1"
+        [title]="attendees[0].title"
+        [alt]="attendees[0].alt"
+        [src]="attendees[0].src"
+      ></cui-avatar>
+    </ng-template>
+  `,
+  host: {
+    'class': 'cui-alert cui-alert--meeting',
+    '[attr.role]': 'clickable ? "button" : null',
+    '[attr.tabindex]': 'clickable ? "0" : null',
+    '(click)': 'clickable ? onClick() : null',
+    '(keydown)': 'clickable ? onKeydown($event) : null',
+  }
+})
+export class AlertMeetingComponent implements OnInit {
+  @Input() private key: string;
+  @Input() attendees: AlertMeetingAttendee[] = [];
+  @Input() avatar: TemplateRef<any>;
+  @Input() clickable: boolean;
+  @Input() closeAriaLabel: string = 'close';
+  @Input() message: string = '';
+  @Input() remindAriaLabel: string = 'snooze';
+  @Input() snoozeButtonVisible: boolean;
+  @Input() status: string = '';
+  @Input() title: string = '';
+
+  @Output() readonly mouseclick: EventEmitter<string> = new EventEmitter<string>();
+  @Output() readonly hide: EventEmitter<string> = new EventEmitter<string>();
+  @Output() readonly snooze: EventEmitter<string> = new EventEmitter<string>();
+
+  get contentClasses(): string[] {
+    return [
+      'cui-alert__content',
+      this.snoozeButtonVisible ? '' : 'cui-alert__content--wide'
+    ];
+  }
+
+  ngOnInit() {
+    if (!this.avatar && this.attendees.length === 0) {
+      throw new Error('MeetingAlert needs at least one attendee to render an avatar.');
+    }
+  }
+
+  onClick(): void {
+    this.mouseclick.emit(this.key);
+  }
+
+  onSnooze(): void {
+    this.snooze.emit(this.key);
+  }
+
+  onHide(): void {
+    this.hide.emit(this.key);
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    if (event.code === 'Space' || event.code === 'Enter') {
+      this.onClick();
+      event.preventDefault();
+    }
+  }
+}

--- a/angular/src/lib/alert-meeting/alert-meeting.module.ts
+++ b/angular/src/lib/alert-meeting/alert-meeting.module.ts
@@ -1,0 +1,28 @@
+import { OverlayModule } from '@angular/cdk/overlay';
+import { PortalModule } from '@angular/cdk/portal';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { AvatarModule } from '../avatar';
+import { ButtonModule } from '../button';
+import { CompositeAvatarModule } from '../composite-avatar';
+import { IconModule } from '../icon';
+import { AlertMeetingComponent } from './alert-meeting.component';
+import { AlertMeetingContainerComponent } from './alert-meeting-container.component';
+import { AlertMeetingService } from './alert-meeting.service';
+
+@NgModule({
+  imports: [
+    OverlayModule,
+    PortalModule,
+    CommonModule,
+    AvatarModule,
+    ButtonModule,
+    CompositeAvatarModule,
+    IconModule,
+  ],
+  declarations: [AlertMeetingComponent, AlertMeetingContainerComponent],
+  exports: [AlertMeetingContainerComponent],
+  entryComponents: [AlertMeetingContainerComponent],
+  providers: [AlertMeetingService]
+})
+export class AlertMeetingModule {}

--- a/angular/src/lib/alert-meeting/alert-meeting.service.ts
+++ b/angular/src/lib/alert-meeting/alert-meeting.service.ts
@@ -1,0 +1,54 @@
+import { Overlay, OverlayRef } from '@angular/cdk/overlay';
+import { ComponentPortal } from '@angular/cdk/portal';
+import { ComponentRef, Injectable, OnDestroy } from '@angular/core';
+import { AlertMeetingConfig } from './alert-meeting-config';
+import { AlertMeetingContainerComponent } from './alert-meeting-container.component';
+
+@Injectable()
+export class AlertMeetingService implements OnDestroy {
+  private _overlayRef?: OverlayRef | null = null;
+  private _alertContainerRef?: ComponentRef<AlertMeetingContainerComponent> | null = null;
+
+  constructor(private _overlay: Overlay) {}
+
+  show(config: AlertMeetingConfig): string {
+    if (!this._overlayRef) {
+      this._overlayRef = this._overlay.create();
+    }
+    const container = this._attachAlertContainer(this._overlayRef);
+    const _config = {...new AlertMeetingConfig(), ...config};
+    return container.addAlert(_config);
+  }
+
+  hide(key: string): void {
+    if (this._alertContainerRef) {
+      this._alertContainerRef.instance.removeAlert(key);
+    }
+  }
+
+  private _attachAlertContainer(overlayRef: OverlayRef): AlertMeetingContainerComponent {
+    if (this._alertContainerRef) {
+      return this._alertContainerRef.instance;
+    }
+
+    const containerPortal = new ComponentPortal(AlertMeetingContainerComponent);
+    this._alertContainerRef = overlayRef.attach(containerPortal);
+    const onDestroySub = this._alertContainerRef.instance._onDestroy.subscribe(() => {
+      onDestroySub.unsubscribe();
+      this._dispose();
+    });
+    return this._alertContainerRef.instance;
+  }
+
+  ngOnDestroy() {
+    if (this._alertContainerRef) {
+      this._alertContainerRef.instance.destroy();
+    }
+  }
+
+  private _dispose(): void {
+    this._alertContainerRef = null;
+    this._overlayRef.dispose();
+    this._overlayRef = null;
+  }
+}

--- a/angular/src/lib/alert-meeting/examples/avatar.component.ts
+++ b/angular/src/lib/alert-meeting/examples/avatar.component.ts
@@ -1,0 +1,27 @@
+import { Component, TemplateRef, ViewChild } from '@angular/core';
+import { AlertMeetingService } from '@collab-ui/angular';
+
+@Component({
+  selector: 'example-alert-meeting-avatar',
+  template: `
+    <button cui-button (click)="onClick()" aria-label="Click to Open">Avatar</button>
+
+    <ng-template #avatarTemplate>
+      <cui-avatar title="Tom Smith" src="http://react.collab-ui.com/barbara.png"></cui-avatar>
+    </ng-template>
+  `,
+})
+export class ExampleAlertMeetingAvatarComponent {
+  @ViewChild('avatarTemplate') avatarTemplate: TemplateRef<any>;
+
+  constructor(private alertMeetingService: AlertMeetingService) {}
+
+  onClick() {
+    this.alertMeetingService.show({
+      title: 'Important Meeting',
+      message: 'This is important',
+      status: 'In 5 mins.',
+      avatar: this.avatarTemplate,
+    });
+  }
+}

--- a/angular/src/lib/alert-meeting/examples/default.component.ts
+++ b/angular/src/lib/alert-meeting/examples/default.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { AlertMeetingService } from '@collab-ui/angular';
+
+@Component({
+  selector: 'example-alert-meeting-default',
+  template: `
+    <button cui-button (click)="onClick()" aria-label="Click to Open">Default</button>
+  `,
+})
+export class ExampleAlertMeetingDefaultComponent {
+  constructor(private alertMeetingService: AlertMeetingService) {}
+
+  onClick() {
+    this.alertMeetingService.show({
+      title: 'Important Meeting',
+      message: 'This is important',
+      status: 'In 5 mins.',
+      attendees: [{title: 'J $'}],
+      onClick: () => {},
+      onHide: () => {},
+      onSnooze: () => {},
+    });
+  }
+}

--- a/angular/src/lib/alert-meeting/examples/examples.module.ts
+++ b/angular/src/lib/alert-meeting/examples/examples.module.ts
@@ -1,0 +1,35 @@
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+
+import {
+  AlertMeetingModule,
+  AvatarModule,
+  ButtonModule,
+  CompositeAvatarModule,
+} from '@collab-ui/angular';
+import {
+  ExampleAlertMeetingAvatarComponent,
+  ExampleAlertMeetingDefaultComponent,
+  ExampleAlertMeetingMultipleComponent,
+} from './index';
+
+@NgModule({
+  imports: [
+    AlertMeetingModule,
+    AvatarModule,
+    ButtonModule,
+    CompositeAvatarModule,
+  ],
+  declarations: [
+    ExampleAlertMeetingAvatarComponent,
+    ExampleAlertMeetingDefaultComponent,
+    ExampleAlertMeetingMultipleComponent,
+  ],
+  exports: [
+    ExampleAlertMeetingAvatarComponent,
+    ExampleAlertMeetingDefaultComponent,
+    ExampleAlertMeetingMultipleComponent,
+  ],
+  providers: [],
+  schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
+})
+export class AlertMeetingExamplesModule { }

--- a/angular/src/lib/alert-meeting/examples/index.ts
+++ b/angular/src/lib/alert-meeting/examples/index.ts
@@ -1,0 +1,3 @@
+export * from './avatar.component';
+export * from './default.component';
+export * from './multiple.component';

--- a/angular/src/lib/alert-meeting/examples/multiple.component.ts
+++ b/angular/src/lib/alert-meeting/examples/multiple.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { AlertMeetingService } from '@collab-ui/angular';
+
+@Component({
+  selector: 'example-alert-meeting-multiple',
+  template: `
+    <button cui-button (click)="onClick()" aria-label="Click to Open">Multiple</button>
+  `,
+})
+export class ExampleAlertMeetingMultipleComponent {
+  constructor(private alertMeetingService: AlertMeetingService) {}
+
+  onClick() {
+    this.alertMeetingService.show({
+      title: 'Important Meeting',
+      message: 'This is important',
+      status: 'In 5 mins.',
+      attendees: [{title: 'J $'}, {title: 'Jefe Guadelupe'}],
+      onClick: () => {},
+      onHide: () => {},
+      onSnooze: () => {},
+    });
+  }
+}

--- a/angular/src/lib/alert-meeting/index.ts
+++ b/angular/src/lib/alert-meeting/index.ts
@@ -1,0 +1,5 @@
+export * from './alert-meeting.module';
+export * from './alert-meeting.service';
+export * from './alert-meeting-container.component';
+export * from './alert-meeting-config';
+export * from './alert-meeting.component';

--- a/angular/src/lib/alert-meeting/tests/__snapshots__/alert-meeting.service.spec.ts.snap
+++ b/angular/src/lib/alert-meeting/tests/__snapshots__/alert-meeting.service.spec.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AlertMeetingService should match snapshot 1`] = `
+<div
+  class="cdk-overlay-container"
+/>
+`;

--- a/angular/src/lib/alert-meeting/tests/alert-meeting.service.spec.ts
+++ b/angular/src/lib/alert-meeting/tests/alert-meeting.service.spec.ts
@@ -1,0 +1,347 @@
+import {
+  async,
+  inject,
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+import { Component, NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { AvatarModule } from '../../avatar';
+import { CompositeAvatarModule } from '../../composite-avatar';
+import { AlertMeetingModule, AlertMeetingService } from '../index';
+
+describe('AlertMeetingService', () => {
+  let alertService: AlertMeetingService;
+  let overlayContainer: OverlayContainer;
+  let overlayContainerElement: HTMLElement;
+  let viewContainerFixture: ComponentFixture<ContainerComponent>;
+
+  const title = 'Important Meeting';
+  const message = 'Attendance Required';
+  const status = 'In 5 mins.';
+
+  const attendeeOne = {title: 'J $'};
+  const attendeeTwo = {title: 'Hee Haw'};
+  const attendeeThree = {title: 'Hollywood Squarepants'};
+
+  const attendeeListOne = [attendeeOne];
+  const attendeeListTwo = [attendeeOne, attendeeTwo];
+  const attendeeListThree = [attendeeOne, attendeeTwo, attendeeThree];
+
+  @Component({
+    selector: 'view-container',
+    template: ``,
+  })
+  class ContainerComponent {}
+
+  @NgModule({
+    imports: [
+      CommonModule,
+      AlertMeetingModule,
+      AvatarModule,
+      CompositeAvatarModule,
+    ],
+    exports: [ContainerComponent],
+    providers: [AlertMeetingService],
+    declarations: [ContainerComponent],
+    entryComponents: [ContainerComponent],
+  })
+  class AlertMeetingTestModule {}
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        AlertMeetingModule,
+        AlertMeetingTestModule,
+        AvatarModule,
+        CompositeAvatarModule,
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+  }));
+
+  beforeEach(inject([AlertMeetingService, OverlayContainer], (service: AlertMeetingService, container: OverlayContainer) => {
+    alertService = service;
+    overlayContainer = container;
+    overlayContainerElement = container.getContainerElement();
+  }));
+
+  afterEach(() => {
+    overlayContainer.ngOnDestroy();
+  });
+
+  beforeEach(() => {
+    viewContainerFixture = TestBed.createComponent(ContainerComponent);
+    viewContainerFixture.detectChanges();
+  });
+
+  it('should match snapshot', () => {
+    expect(overlayContainerElement).toMatchSnapshot();
+  });
+
+  it('should render one AlertMeeting', () => {
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListOne,
+    });
+    viewContainerFixture.detectChanges();
+
+    const container = overlayContainerElement.querySelector('cui-alert-meeting-container');
+    expect(container).not.toBeNull();
+    const element = container.querySelector('cui-alert-meeting');
+    expect(element).not.toBeNull();
+    expect(element.className).toContain('cui-alert--meeting');
+  });
+
+  it('should render meeting title', () => {
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListOne,
+    });
+    viewContainerFixture.detectChanges();
+
+    const element = overlayContainerElement.querySelector('.cui-alert__title');
+    expect(element.textContent).toEqual(title);
+  });
+
+  it('should render meeting message', () => {
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListOne,
+    });
+    viewContainerFixture.detectChanges();
+
+    const element = overlayContainerElement.querySelector('.cui-alert__message');
+    expect(element.textContent).toEqual(message);
+  });
+
+  it('should render meeting status', () => {
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListOne,
+    });
+    viewContainerFixture.detectChanges();
+
+    const element = overlayContainerElement.querySelector('.cui-alert__status');
+    expect(element.textContent).toEqual(status);
+  });
+
+  it('should render an avatar', () => {
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListOne,
+    });
+    viewContainerFixture.detectChanges();
+
+    const element = overlayContainerElement.querySelectorAll('cui-avatar');
+    expect(element.length).toEqual(1);
+  });
+
+  it('should only render a close button when onSnooze is not passed in', () => {
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListOne,
+    });
+    viewContainerFixture.detectChanges();
+
+    const element = overlayContainerElement.querySelectorAll('.cui-button');
+    expect(element.length).toEqual(1);
+  });
+
+  it('should render snooze button when onSnooze is passed in', () => {
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListOne,
+      onSnooze: () => {}
+    });
+    viewContainerFixture.detectChanges();
+
+    const element = overlayContainerElement.querySelectorAll('.cui-button');
+    expect(element.length).toEqual(2);
+  });
+
+  it('should handle snooze aria-label when remindAriaLabel is passed in', () => {
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListOne,
+      remindAriaLabel: 'testSnooze',
+      onSnooze: () => {}
+    });
+    viewContainerFixture.detectChanges();
+
+    const element = overlayContainerElement.querySelectorAll('.cui-button');
+    expect(element[0].getAttribute('aria-label')).toEqual('testSnooze');
+  });
+
+  it('should handle close aria-label when closeAriaLabel is passed in', () => {
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListOne,
+      closeAriaLabel: 'testClose',
+      onHide: () => {}
+    });
+    viewContainerFixture.detectChanges();
+
+    const element = overlayContainerElement.querySelectorAll('.cui-button');
+    expect(element[0].getAttribute('aria-label')).toEqual('testClose');
+  });
+
+  it('should use cui-alert__content class when onSnooze is passed in', () => {
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListOne,
+      onSnooze: () => {}
+    });
+    viewContainerFixture.detectChanges();
+
+    expect(overlayContainerElement.querySelectorAll('.cui-alert__content').length).toEqual(1);
+    expect(overlayContainerElement.querySelectorAll('.cui-alert__content--wide').length).toEqual(0);
+  });
+
+  it('should use cui-alert__content--wide class when onSnooze is not passed in', () => {
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListOne,
+    });
+    viewContainerFixture.detectChanges();
+
+    expect(overlayContainerElement.querySelectorAll('.cui-alert__content').length).toEqual(1);
+    expect(overlayContainerElement.querySelectorAll('.cui-alert__content--wide').length).toEqual(1);
+  });
+
+  it('should render a composite avatar when attendee list is greater than 1', () => {
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListTwo,
+    });
+    viewContainerFixture.detectChanges();
+
+    expect(overlayContainerElement.querySelectorAll('cui-composite-avatar').length).toEqual(1);
+    expect(overlayContainerElement.querySelectorAll('cui-avatar').length).toEqual(2);
+  });
+
+  it('should render a composite avatar with only 2 avatars when attendee list is greater than 2', () => {
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListThree,
+    });
+    viewContainerFixture.detectChanges();
+
+    expect(overlayContainerElement.querySelectorAll('cui-composite-avatar').length).toEqual(1);
+    expect(overlayContainerElement.querySelectorAll('cui-avatar').length).toEqual(2);
+  });
+
+  it('should handle onClick event', () => {
+    let count = 0;
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListOne,
+      onClick: () => count++
+    });
+    viewContainerFixture.detectChanges();
+
+    const element = overlayContainerElement.querySelector('.cui-alert--meeting');
+    (element as HTMLButtonElement).click();
+    expect(count).toBe(1);
+  });
+
+  it('should handle space keyDown event', () => {
+    let count = 0;
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListOne,
+      onClick: () => count++
+    });
+    viewContainerFixture.detectChanges();
+
+    overlayContainerElement.querySelector('.cui-alert').dispatchEvent(
+      new KeyboardEvent('keydown', {
+        code: 'Space',
+      })
+    );
+    expect(count).toBe(1);
+  });
+
+  it('should handle enter keyDown event', () => {
+    let count = 0;
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListOne,
+      onClick: () => count++
+    });
+    viewContainerFixture.detectChanges();
+
+    overlayContainerElement.querySelector('.cui-alert').dispatchEvent(
+      new KeyboardEvent('keydown', {
+        code: 'Enter',
+      })
+    );
+    expect(count).toBe(1);
+  });
+
+  it('should handle onSnooze event', () => {
+    let count = 0;
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListOne,
+      onSnooze: () => count++
+    });
+    viewContainerFixture.detectChanges();
+
+    const element = overlayContainerElement.querySelectorAll('.cui-button');
+    (element[0] as HTMLButtonElement).click();
+    expect(count).toBe(1);
+  });
+
+  it('should handle onHide event', () => {
+    let count = 0;
+    alertService.show({
+      title: title,
+      message: message,
+      status: status,
+      attendees: attendeeListOne,
+      onHide: () => count++
+    });
+    viewContainerFixture.detectChanges();
+
+    const element = overlayContainerElement.querySelectorAll('.cui-button');
+    (element[0] as HTMLButtonElement).click();
+    expect(count).toBe(1);
+  });
+
+});

--- a/angular/src/lib/examples.module.ts
+++ b/angular/src/lib/examples.module.ts
@@ -2,6 +2,7 @@ import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 import { AlertExamplesModule } from './alert/examples/examples.module';
 import { AlertBannerExamplesModule } from './alert-banner/examples/examples.module';
+import { AlertMeetingExamplesModule } from './alert-meeting/examples/examples.module';
 import { AvatarExamplesModule } from './avatar/examples/examples.module';
 import { BadgeExamplesModule } from './badge/examples/examples.module';
 import { ButtonExamplesModule } from './button/examples/examples.module';
@@ -20,6 +21,7 @@ import { TopbarExamplesModule } from './topbar/examples/examples.module';
   imports: [
     AlertExamplesModule,
     AlertBannerExamplesModule,
+    AlertMeetingExamplesModule,
     AvatarExamplesModule,
     BadgeExamplesModule,
     ButtonExamplesModule,
@@ -37,6 +39,7 @@ import { TopbarExamplesModule } from './topbar/examples/examples.module';
   exports: [
     AlertExamplesModule,
     AlertBannerExamplesModule,
+    AlertMeetingExamplesModule,
     AvatarExamplesModule,
     BadgeExamplesModule,
     ButtonExamplesModule,

--- a/angular/src/lib/public_api.ts
+++ b/angular/src/lib/public_api.ts
@@ -3,6 +3,7 @@
  */
 
 export * from './alert-banner';
+export * from './alert-meeting';
 export * from './alert';
 export * from './avatar';
 export * from './badge';


### PR DESCRIPTION

![meeting alert](https://user-images.githubusercontent.com/12623703/55126428-fff0a680-5147-11e9-9755-56d18622624f.png)


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
